### PR TITLE
refactor: update signal example

### DIFF
--- a/examples/motion-canvas/src/scenes/signals.tsx
+++ b/examples/motion-canvas/src/scenes/signals.tsx
@@ -157,6 +157,7 @@ export default makeScene2D(function* (view) {
         fill={'#ff6470'}
         radius={8}
         scale={0}
+        rotation={() => -145 + 80 * circle().scale.x()}
       />
       <Line
         ref={arrow}
@@ -182,7 +183,7 @@ export default makeScene2D(function* (view) {
   yield* waitUntil('circle');
   yield* circle().scale(1.5, 0.5, easeOutCubic);
   const task2 = yield loop(Infinity, () =>
-    all(circle().scale(1, 1).to(1.5, 1), square().rotation(-65, 1).to(-25, 1)),
+    circle().scale(1, 1).to(1.5, 1),
   );
 
   yield* waitUntil('square');


### PR DESCRIPTION
Update Rect's rotation property to change based on Circle's scale signal instead of changing both at the same time. This is visually identical to the existing video/example, but might make the correlation between the scale & rotation more apparent for anyone picking up these examples.